### PR TITLE
Added compatibility with earlier version of vim. Updated taglist to 4.6.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 ## Sell
 
-Hey, ever used TextMate and discovered the great *Go to Symbol* feature, but
+Hey, ever used TextMate or Sublime Text and discovered the great *Go to Symbol* feature, but
 was disheartened that it was one of the last features that hadn't been
 duplicated for Vim?
 

--- a/doc/taglist.txt
+++ b/doc/taglist.txt
@@ -2,7 +2,7 @@
 
 Author: Yegappan Lakshmanan  (yegappan AT yahoo DOT com)
 For Vim version 6.0 and above
-Last change: 2007 May 24
+Last change: 2013 Feburary 26
 
 1. Overview 					|taglist-intro|
 2. Taglist on the internet			|taglist-internet|
@@ -760,6 +760,12 @@ loaded. Examples:
 	let Tlist_Ctags_Cmd = 'd:\tools\ctags.exe'
 	let Tlist_Ctags_Cmd = '/usr/local/bin/ctags'
 <
+On Microsoft Windows, if ctags.exe is installed in a directory with space
+characters in the name (e.g. C:\Program Files\ctags\ctags.exe), then you need
+to set the Tlist_Ctags_Cmd variable like this:
+>
+	let Tlist_Ctags_Cmd = '"C:\Program Files\ctags\ctags.exe"'
+<
 						*'Tlist_Display_Prototype'*
 Tlist_Display_Prototype~
 By default, only the tag name will be displayed in the taglist window. If you
@@ -841,6 +847,7 @@ If your terminal doesn't support changing the window width from Vim (older
 version of xterm running in a Unix system) or if you see any weird problems in
 the screen due to the change in the window width or if you prefer not to
 adjust the window width then set the 'Tlist_Inc_Winwidth' variable to zero.
+If you are using GNU Screen, you may want to set this variable to zero.
 CAUTION: If you are using the MS-Windows version of Vim in a MS-DOS command
 window then you must set this variable to zero, otherwise the system may hang
 due to a Vim limitation (explained in :help win32-problems)
@@ -1144,6 +1151,7 @@ The taglist plugin provides several global functions that can be used from
 other Vim plugins to interact with the taglist plugin. These functions are
 described below.
 
+|Tlist_Get_Filenames()|			Return filenames in the taglist
 |Tlist_Update_File_Tags()|		Update the tags for the specified file
 |Tlist_Get_Tag_Prototype_By_Line()|	Return the prototype of the tag at or
 				    	before the specified line number in the
@@ -1153,6 +1161,12 @@ described below.
 					the specified file.
 |Tlist_Set_App()|			Set the name of the application
 					controlling the taglist window.
+
+					    *Tlist_Get_Filenames()*
+Tlist_Get_Filenames()
+		Returns a list of filenames in the taglist. Each filename is
+		separated by a newline (\n) character. If the taglist is empty
+		an empty string is returned.
 
 					    *Tlist_Update_File_Tags()*
 Tlist_Update_File_Tags({filename}, {filetype})

--- a/plugin/taglist.vim
+++ b/plugin/taglist.vim
@@ -1,7 +1,8 @@
 " File: taglist.vim
 " Author: Yegappan Lakshmanan (yegappan AT yahoo DOT com)
 " Contributions: Travis Jeffery <twitter.com/travisjeffery>
-" Version: 4.6
+"                Yohanna Gadelrab <github.com/Yohanna>
+" Taglist Version: 4.5
 " Last Modified: April 21, 2011
 " Copyright: Copyright (C) 2002-2007 Yegappan Lakshmanan
 "            Permission is hereby granted to use and distribute this code,
@@ -359,7 +360,12 @@ if !exists('loaded_taglist')
         endif
     endfunction
 
-    command! -bar -nargs=1 -complete=customlist,s:completeSymbols GotoSymbol :call s:gotoSymbol('<args>')
+    if version >= 700 " 7.0
+         command! -bar -nargs=1 -complete=customlist,s:completeSymbols GotoSymbol :call s:gotoSymbol('<args>')
+    else
+         " No auto-completion for you!
+         command! -bar -nargs=1 GotoSymbol :call s:gotoSymbol('<args>')
+    endif
 
     " restore 'cpo'
     let &cpo = s:cpo_save

--- a/plugin/taglist.vim
+++ b/plugin/taglist.vim
@@ -2,9 +2,9 @@
 " Author: Yegappan Lakshmanan (yegappan AT yahoo DOT com)
 " Contributions: Travis Jeffery <twitter.com/travisjeffery>
 "                Yohanna Gadelrab <github.com/Yohanna>
-" Taglist Version: 4.5
-" Last Modified: April 21, 2011
-" Copyright: Copyright (C) 2002-2007 Yegappan Lakshmanan
+" Version: 4.6
+" Last Modified: Feb 26, 2013
+" Copyright: Copyright (C) 2002-2013 Yegappan Lakshmanan
 "            Permission is hereby granted to use and distribute this code,
 "            with or without modifications, provided that this copyright
 "            notice is copied with it. Like anything else that's free,
@@ -59,7 +59,12 @@
 " ****************** Do not modify after this line ************************
 
 " Line continuation used here
-let s:cpo_save = &cpo
+if !exists('s:cpo_save')
+    " If the taglist plugin is sourced recursively, the 'cpo' setting will be
+    " set to the default value.  To avoid this problem, save the cpo setting
+    " only when the plugin is loaded for the first time.
+    let s:cpo_save = &cpo
+endif
 set cpo&vim
 
 if !exists('loaded_taglist')
@@ -214,7 +219,7 @@ if !exists('loaded_taglist')
     if !exists('Tlist_Auto_Highlight_Tag')
         let Tlist_Auto_Highlight_Tag = 1
     endif
-
+    
     " Automatically highlight the current tag on entering a buffer
     if !exists('Tlist_Highlight_Tag_On_BufEnter')
         let Tlist_Highlight_Tag_On_BufEnter = 1
@@ -278,7 +283,7 @@ if !exists('loaded_taglist')
     command! -nargs=0 -bar TlistClose call s:Tlist_Window_Close()
     command! -nargs=0 -bar TlistUpdate call s:Tlist_Update_Current_File()
     command! -nargs=0 -bar TlistHighlightTag call s:Tlist_Window_Highlight_Tag(
-                \ fnamemodify(bufname('%'), ':p'), line('.'), 2, 1)
+                        \ fnamemodify(bufname('%'), ':p'), line('.'), 2, 1)
     " For backwards compatiblity define the TlistSync command
     command! -nargs=0 -bar TlistSync TlistHighlightTag
     command! -nargs=* -complete=buffer TlistShowPrototype
@@ -303,7 +308,7 @@ if !exists('loaded_taglist')
     " Trick to get the current script ID
     map <SID>xx <SID>xx
     let s:tlist_sid = substitute(maparg('<SID>xx'), '<SNR>\(\d\+_\)xx$',
-                \ '\1', '')
+                                \ '\1', '')
     unmap <SID>xx
 
     exe 'autocmd FuncUndefined *' . s:tlist_sid . 'Tlist_* source ' .
@@ -361,7 +366,7 @@ if !exists('loaded_taglist')
     endfunction
 
     if version >= 700 " 7.0
-         command! -bar -nargs=1 -complete=customlist,s:completeSymbols GotoSymbol :call s:gotoSymbol('<args>')
+    command! -bar -nargs=1 -complete=customlist,s:completeSymbols GotoSymbol :call s:gotoSymbol('<args>')
     else
          " No auto-completion for you!
          command! -bar -nargs=1 GotoSymbol :call s:gotoSymbol('<args>')
@@ -375,6 +380,7 @@ endif
 if !exists('s:tlist_sid')
     " Two or more versions of taglist plugin are installed. Don't
     " load this version of the plugin.
+    let &cpo = s:cpo_save
     finish
 endif
 
@@ -409,37 +415,53 @@ let loaded_taglist = 'available'
 "               tags of this type
 "
 
+" Ant language
+let s:tlist_def_ant_settings = 'ant;p:projects;t:targets'
+
 " assembly language
 let s:tlist_def_asm_settings = 'asm;d:define;l:label;m:macro;t:type'
 
 " aspperl language
-let s:tlist_def_aspperl_settings = 'asp;f:function;s:sub;v:variable'
+let s:tlist_def_aspperl_settings =
+            \ 'asp;c:constants;v:variable;f:function;s:subroutine'
 
 " aspvbs language
-let s:tlist_def_aspvbs_settings = 'asp;f:function;s:sub;v:variable'
+let s:tlist_def_aspvbs_settings =
+            \ 'asp;c:constants;v:variable;f:function;s:subroutine'
 
 " awk language
 let s:tlist_def_awk_settings = 'awk;f:function'
+
+" basic language
+let s:tlist_def_basic_settings =
+            \ 'basic;c:constant;l:label;g:enum;v:variable;' .
+            \ 't:type;f:function'
 
 " beta language
 let s:tlist_def_beta_settings = 'beta;f:fragment;s:slot;v:pattern'
 
 " c language
 let s:tlist_def_c_settings = 'c;d:macro;g:enum;s:struct;u:union;t:typedef;' .
-            \ 'v:variable;f:function'
+                           \ 'v:variable;f:function'
 
 " c++ language
 let s:tlist_def_cpp_settings = 'c++;n:namespace;v:variable;d:macro;t:typedef;' .
-            \ 'c:class;g:enum;s:struct;u:union;f:function'
+                             \ 'c:class;g:enum;s:struct;u:union;f:function'
 
 " c# language
 let s:tlist_def_cs_settings = 'c#;d:macro;t:typedef;n:namespace;c:class;' .
-            \ 'E:event;g:enum;s:struct;i:interface;' .
-            \ 'p:properties;m:method'
+                             \ 'E:event;g:enum;s:struct;i:interface;' .
+                             \ 'p:properties;m:method'
 
 " cobol language
 let s:tlist_def_cobol_settings = 'cobol;d:data;f:file;g:group;p:paragraph;' .
-            \ 'P:program;s:section'
+                               \ 'P:program;s:section'
+" D programming language
+let s:tlist_def_d_settings = 'c++;n:namespace;v:variable;t:typedef;' .
+                        \'c:class;g:enum;s:struct;u:union;f:function'
+
+" Dosbatch
+let s:tlist_def_dosbatch_settings = 'dosbatch;l:labels;v:variables'
 
 " eiffel language
 let s:tlist_def_eiffel_settings = 'eiffel;c:class;f:feature'
@@ -450,20 +472,28 @@ let s:tlist_def_erlang_settings = 'erlang;d:macro;r:record;m:module;f:function'
 " expect (same as tcl) language
 let s:tlist_def_expect_settings = 'tcl;c:class;f:method;p:procedure'
 
+" flex
+let s:tlist_def_flex_settings = 'flex;v:global;c:classes;p:properties;'.
+            \ 'm:methods;f:functions;x:mxtags'
+
 " fortran language
 let s:tlist_def_fortran_settings = 'fortran;p:program;b:block data;' .
-            \ 'c:common;e:entry;i:interface;k:type;l:label;m:module;' .
-            \ 'n:namelist;t:derived;v:variable;f:function;s:subroutine'
+                    \ 'c:common;e:entry;i:interface;k:type;l:label;m:module;' .
+                    \ 'n:namelist;t:derived;v:variable;f:function;s:subroutine'
+
+" GO language
+let s:tlist_def_go_settings = 'go;f:function;p:package;t:struct'
 
 " HTML language
-let s:tlist_def_html_settings = 'html;a:anchor;f:javascript function'
+let s:tlist_def_html_settings = 'html;a:anchor;f:function'
 
 " java language
 let s:tlist_def_java_settings = 'java;p:package;c:class;i:interface;' .
-            \ 'f:field;m:method'
+                              \ 'g:enum;f:field;m:method'
 
 " javascript language
-let s:tlist_def_javascript_settings = 'javascript;f:function'
+let s:tlist_def_javascript_settings =
+            \ 'javascript;c:class;m:method;v:global;f:function;p:properties'
 
 " lisp language
 let s:tlist_def_lisp_settings = 'lisp;f:function'
@@ -474,6 +504,13 @@ let s:tlist_def_lua_settings = 'lua;f:function'
 " makefiles
 let s:tlist_def_make_settings = 'make;m:macro'
 
+" Matlab
+let s:tlist_def_matlab_settings = 'matlab;f:function'
+
+" Ocamal
+let s:tlist_def_ocamal_settings = 'ocamal;M:module;v:global;t:type;'.
+            \ 'c:class;f:function;m:method;C:constructor;e:exception'
+
 " pascal language
 let s:tlist_def_pascal_settings = 'pascal;f:function;p:procedure'
 
@@ -481,17 +518,21 @@ let s:tlist_def_pascal_settings = 'pascal;f:function;p:procedure'
 let s:tlist_def_perl_settings = 'perl;c:constant;l:label;p:package;s:subroutine'
 
 " php language
-let s:tlist_def_php_settings = 'php;c:class;d:constant;v:variable;f:function'
+let s:tlist_def_php_settings =
+            \ 'php;c:class;i:interface;d:constant;v:variable;f:function'
 
 " python language
 let s:tlist_def_python_settings = 'python;c:class;m:member;f:function'
+
+" cython language
+let tlist_pyrex_settings='python;c:classe;m:memder;f:function'
 
 " rexx language
 let s:tlist_def_rexx_settings = 'rexx;s:subroutine'
 
 " ruby language
 let s:tlist_def_ruby_settings = 'ruby;c:class;f:method;F:function;' .
-            \ 'm:singleton method'
+                              \ 'm:singleton method'
 
 " scheme language
 let s:tlist_def_scheme_settings = 'scheme;s:set;f:function'
@@ -510,27 +551,44 @@ let s:tlist_def_slang_settings = 'slang;n:namespace;f:function'
 
 " sml language
 let s:tlist_def_sml_settings = 'sml;e:exception;c:functor;s:signature;' .
-            \ 'r:structure;t:type;v:value;f:function'
+            \ 'r:structure;t:type;v:value;c:functor;f:function'
 
 " sql language
-let s:tlist_def_sql_settings = 'sql;c:cursor;F:field;P:package;r:record;' .
-            \ 's:subtype;t:table;T:trigger;v:variable;f:function;p:procedure'
+let s:tlist_def_sql_settings = 'sql;f:functions;' .
+           \ 'P:packages;p:procedures;t:tables;T:triggers;' .
+           \ 'v:variables;e:events;U:publications;R:services;' .
+           \ 'D:domains;x:MLTableScripts;y:MLConnScripts;z:MLProperties;'.
+           \ 'i:indexes;c:cursors;V:views;'.
+           \ 'd:prototypes;'.
+           \ 'l:local variables;'.
+           \ 'F:record fields;'.
+           \ 'L:block label;'.
+           \ 'r:records;'.
+           \ 's:subtypes'
 
 " tcl language
 let s:tlist_def_tcl_settings = 'tcl;c:class;f:method;m:method;p:procedure'
 
+" Tex
+let s:tlist_def_tex_settings = 'tex;c:chapters;s:sections;u:subsections;'.
+            \ 'b:subsubsections;p:parts;P:paragraphs;G:subparagraphs'
+
 " vera language
 let s:tlist_def_vera_settings = 'vera;c:class;d:macro;e:enumerator;' .
-            \ 'f:function;g:enum;m:member;p:program;' .
-            \ 'P:prototype;t:task;T:typedef;v:variable;' .
-            \ 'x:externvar'
+                                \ 'f:function;g:enum;m:member;p:program;' .
+                                \ 'P:prototype;t:task;T:typedef;v:variable;' .
+                                \ 'x:externvar'
 
 "verilog language
 let s:tlist_def_verilog_settings = 'verilog;m:module;c:constant;P:parameter;' .
             \ 'e:event;r:register;t:task;w:write;p:port;v:variable;f:function'
 
+" VHDL
+let s:tlist_def_vhdl_settings = 'vhdl;c:constant;t:type;T:subtype;r:record;e:entity;f:function;p:procedure;P:package'
+
 " vim language
-let s:tlist_def_vim_settings = 'vim;a:autocmds;v:variable;f:function'
+let s:tlist_def_vim_settings =
+            \ 'vim;v:variable;a:autocmds;c:commands;m:map;f:function'
 
 " yacc language
 let s:tlist_def_yacc_settings = 'yacc;l:label'
@@ -988,7 +1046,7 @@ function! s:Tlist_FileType_Init(ftype)
     endwhile
 
     let s:tlist_{a:ftype}_ctags_args = '--language-force=' . ctags_ftype .
-                \ ' --' . ctags_ftype . '-types=' . ctags_flags
+                            \ ' --' . ctags_ftype . '-types=' . ctags_flags
     let s:tlist_{a:ftype}_count = cnt
     let s:tlist_{a:ftype}_ctags_flags = ctags_flags
 
@@ -1029,6 +1087,12 @@ endfunction
 function! s:Tlist_Get_Buffer_Filetype(bnum)
     let buf_ft = getbufvar(a:bnum, '&filetype')
 
+    " Check whether 'filetype' contains multiple file types separated by '.'
+    " If it is, then use the first file type
+    if buf_ft =~ '\.'
+        let buf_ft = matchstr(buf_ft, '[^.]\+')
+    endif
+
     if bufloaded(a:bnum)
         " For loaded buffers, the 'filetype' is already determined
         return buf_ft
@@ -1067,6 +1131,7 @@ function! s:Tlist_Discard_TagInfo(fidx)
         unlet! {fidx_i}_tag_type
         unlet! {fidx_i}_ttype_idx
         unlet! {fidx_i}_tag_proto
+        unlet! {fidx_i}_tag_scope
         unlet! {fidx_i}_tag_searchpat
         unlet! {fidx_i}_tag_linenum
         let i = i + 1
@@ -1252,6 +1317,7 @@ function! s:Tlist_Remove_File(file_idx, user_request)
             let s:tlist_{j}_{k}_tag_type = s:Tlist_Get_Tag_Type_By_Tag(i, k)
             let s:tlist_{j}_{k}_ttype_idx = s:tlist_{i}_{k}_ttype_idx
             let s:tlist_{j}_{k}_tag_proto = s:Tlist_Get_Tag_Prototype(i, k)
+            let s:tlist_{j}_{k}_tag_scope = s:Tlist_Get_Tag_Scope(i, k)
             let s:tlist_{j}_{k}_tag_searchpat = s:Tlist_Get_Tag_SearchPat(i, k)
             let s:tlist_{j}_{k}_tag_linenum = s:Tlist_Get_Tag_Linenum(i, k)
             let k = k + 1
@@ -1374,7 +1440,9 @@ function! s:Tlist_Window_Create()
     endif
 
     " Create the taglist window
-    exe 'silent! ' . win_dir . ' ' . win_size . 'split ' . wcmd
+    " Preserve the alternate file
+    let cmd_mod = (v:version >= 700) ? 'keepalt ' : ''
+    exe 'silent! ' . cmd_mod . win_dir . ' ' . win_size . 'split ' . wcmd
 
     " Save the new window position
     let s:tlist_winx = getwinposx()
@@ -1460,22 +1528,27 @@ function! s:Tlist_Window_Exit_Only_Window()
     " Before quitting Vim, delete the taglist buffer so that
     " the '0 mark is correctly set to the previous buffer.
     if v:version < 700
-        if winbufnr(2) == -1
+	if winbufnr(2) == -1
             bdelete
-            quit
-        endif
+	    quit
+	endif
     else
-        if winbufnr(2) == -1
-            if tabpagenr('$') == 1
-                " Only one tag page is present
+	if winbufnr(2) == -1
+	    if tabpagenr('$') == 1
+		" Only one tag page is present
+                "
+                " When deleting the taglist buffer, autocommands cannot be
+                " disabled. If autocommands are disabled, then on exiting Vim,
+                " the window size will not be restored back to the original
+                " size.
                 bdelete
-                quit
-            else
-                " More than one tab page is present. Close only the current
-                " tab page
+		quit
+	    else
+		" More than one tab page is present. Close only the current
+		" tab page
                 close
-            endif
-        endif
+	    endif
+	endif
     endif
 endfunction
 
@@ -1572,6 +1645,9 @@ function! s:Tlist_Window_Init()
     " taglist window. So forcefully disable 'number' option for the taglist
     " window
     silent! setlocal nonumber
+    if exists('&relativenumber')
+        silent! setlocal norelativenumber
+    endif
 
     " Use fixed height when horizontally split window is used
     if g:Tlist_Use_Horiz_Window
@@ -1603,10 +1679,10 @@ function! s:Tlist_Window_Init()
     nnoremap <buffer> <silent> P
                 \ :call <SID>Tlist_Window_Jump_To_Tag('prevwin')<CR>
     if v:version >= 700
-        nnoremap <buffer> <silent> t
-                    \ :call <SID>Tlist_Window_Jump_To_Tag('checktab')<CR>
-        nnoremap <buffer> <silent> <C-t>
-                    \ :call <SID>Tlist_Window_Jump_To_Tag('newtab')<CR>
+    nnoremap <buffer> <silent> t
+                \ :call <SID>Tlist_Window_Jump_To_Tag('checktab')<CR>
+    nnoremap <buffer> <silent> <C-t>
+                \ :call <SID>Tlist_Window_Jump_To_Tag('newtab')<CR>
     endif
     nnoremap <buffer> <silent> <2-LeftMouse>
                 \ :call <SID>Tlist_Window_Jump_To_Tag('useopen')<CR>
@@ -1643,10 +1719,10 @@ function! s:Tlist_Window_Init()
     inoremap <buffer> <silent> P
                 \ <C-o>:call <SID>Tlist_Window_Jump_To_Tag('prevwin')<CR>
     if v:version >= 700
-        inoremap <buffer> <silent> t
-                    \ <C-o>:call <SID>Tlist_Window_Jump_To_Tag('checktab')<CR>
-        inoremap <buffer> <silent> <C-t>
-                    \ <C-o>:call <SID>Tlist_Window_Jump_To_Tag('newtab')<CR>
+    inoremap <buffer> <silent> t
+                \ <C-o>:call <SID>Tlist_Window_Jump_To_Tag('checktab')<CR>
+    inoremap <buffer> <silent> <C-t>
+                \ <C-o>:call <SID>Tlist_Window_Jump_To_Tag('newtab')<CR>
     endif
     inoremap <buffer> <silent> <2-LeftMouse>
                 \ <C-o>:call <SID>Tlist_Window_Jump_To_Tag('useopen')<CR>
@@ -1660,9 +1736,9 @@ function! s:Tlist_Window_Init()
     inoremap <buffer> <silent> <kMinus>      <C-o>:silent! foldclose<CR>
     inoremap <buffer> <silent> <kMultiply>   <C-o>:silent! %foldopen!<CR>
     inoremap <buffer> <silent> <Space>       <C-o>:call
-                \ <SID>Tlist_Window_Show_Info()<CR>
+                                    \ <SID>Tlist_Window_Show_Info()<CR>
     inoremap <buffer> <silent> u
-                \ <C-o>:call <SID>Tlist_Window_Update_File()<CR>
+                            \ <C-o>:call <SID>Tlist_Window_Update_File()<CR>
     inoremap <buffer> <silent> d    <C-o>:call <SID>Tlist_Remove_File(-1, 1)<CR>
     inoremap <buffer> <silent> x    <C-o>:call <SID>Tlist_Window_Zoom()<CR>
     inoremap <buffer> <silent> [[   <C-o>:call <SID>Tlist_Window_Move_To_File(-1)<CR>
@@ -1703,19 +1779,19 @@ function! s:Tlist_Window_Init()
         autocmd CursorHold __Tag_List__ call s:Tlist_Window_Show_Info()
         " Highlight the current tag periodically
         autocmd CursorHold * silent call s:Tlist_Window_Highlight_Tag(
-                    \ fnamemodify(bufname('%'), ':p'), line('.'), 1, 0)
+                            \ fnamemodify(bufname('%'), ':p'), line('.'), 1, 0)
 
         " Adjust the Vim window width when taglist window is closed
         autocmd BufUnload __Tag_List__ call s:Tlist_Post_Close_Cleanup()
         " Close the fold for this buffer when leaving the buffer
         if g:Tlist_File_Fold_Auto_Close
             autocmd BufEnter * silent
-                        \ call s:Tlist_Window_Open_File_Fold(expand('<abuf>'))
+                \ call s:Tlist_Window_Open_File_Fold(expand('<abuf>'))
         endif
         " Exit Vim itself if only the taglist window is present (optional)
         if g:Tlist_Exit_OnlyWindow
-            autocmd BufEnter __Tag_List__ nested
-                        \ call s:Tlist_Window_Exit_Only_Window()
+	    autocmd BufEnter __Tag_List__ nested
+			\ call s:Tlist_Window_Exit_Only_Window()
         endif
         if s:tlist_app_name != "winmanager" &&
                     \ !g:Tlist_Process_File_Always &&
@@ -1846,24 +1922,24 @@ function! s:Tlist_Post_Close_Cleanup()
     endif
 
     if s:tlist_app_name != "winmanager"
-        if g:Tlist_Use_Horiz_Window || g:Tlist_Inc_Winwidth == 0 ||
-                    \ s:tlist_winsize_chgd != 1 ||
-                    \ &columns < (80 + g:Tlist_WinWidth)
-            " No need to adjust window width if using horizontally split taglist
-            " window or if columns is less than 101 or if the user chose not to
-            " adjust the window width
-        else
-            " If the user didn't manually move the window, then restore the window
-            " position to the pre-taglist position
-            if s:tlist_pre_winx != -1 && s:tlist_pre_winy != -1 &&
-                        \ getwinposx() == s:tlist_winx &&
-                        \ getwinposy() == s:tlist_winy
-                exe 'winpos ' . s:tlist_pre_winx . ' ' . s:tlist_pre_winy
-            endif
-
-            " Adjust the Vim window width
-            let &columns= &columns - (g:Tlist_WinWidth + 1)
+    if g:Tlist_Use_Horiz_Window || g:Tlist_Inc_Winwidth == 0 ||
+                \ s:tlist_winsize_chgd != 1 ||
+                \ &columns < (80 + g:Tlist_WinWidth)
+        " No need to adjust window width if using horizontally split taglist
+        " window or if columns is less than 101 or if the user chose not to
+        " adjust the window width
+    else
+        " If the user didn't manually move the window, then restore the window
+        " position to the pre-taglist position
+        if s:tlist_pre_winx != -1 && s:tlist_pre_winy != -1 &&
+                    \ getwinposx() == s:tlist_winx &&
+                    \ getwinposy() == s:tlist_winy
+            exe 'winpos ' . s:tlist_pre_winx . ' ' . s:tlist_pre_winy
         endif
+
+        " Adjust the Vim window width
+        let &columns= &columns - (g:Tlist_WinWidth + 1)
+    endif
     endif
 
     let s:tlist_winsize_chgd = -1
@@ -1994,11 +2070,6 @@ function! s:Tlist_Window_Refresh_File(filename, ftype)
 
             let {fidx_ttype}_offset = ttype_start_lnum - file_start
 
-            " create a fold for this tag type
-            let fold_start = ttype_start_lnum
-            let fold_end = fold_start + {fidx_ttype}_count
-            exe fold_start . ',' . fold_end  . 'fold'
-
             " Adjust the cursor position
             if g:Tlist_Compact_Format == 0
                 exe ttype_start_lnum + {fidx_ttype}_count
@@ -2022,10 +2093,7 @@ function! s:Tlist_Window_Refresh_File(filename, ftype)
 
     let s:tlist_{fidx}_end = line('.') - 1
 
-    " Create a fold for the entire file
-    exe s:tlist_{fidx}_start . ',' . s:tlist_{fidx}_end . 'fold'
-    exe 'silent! ' . s:tlist_{fidx}_start . ',' .
-                \ s:tlist_{fidx}_end . 'foldopen!'
+    call s:Tlist_Create_Folds_For_File(fidx)
 
     " Goto the starting line for this file,
     exe s:tlist_{fidx}_start
@@ -2133,6 +2201,25 @@ function! s:Tlist_Get_Tag_Prototype(fidx, tidx)
     return {tproto_var}
 endfunction
 
+" Tlist_Get_Tag_Scope
+" Get the scope (e.g. C++ class) of a tag
+"
+" Tag scope is the last field after the 'line:<num>\t' field
+function! s:Tlist_Get_Tag_Scope(fidx, tidx)
+    let tscope_var = 's:tlist_' . a:fidx . '_' . a:tidx . '_tag_scope'
+
+    " Already parsed and have the tag scope
+    if exists(tscope_var)
+        return {tscope_var}
+    endif
+
+    " Parse and extract the tag scope
+    let tag_line = s:tlist_{a:fidx}_{a:tidx}_tag
+    let {tscope_var} = s:Tlist_Extract_Tag_Scope(tag_line)
+
+    return {tscope_var}
+endfunction
+
 " Tlist_Get_Tag_SearchPat
 function! s:Tlist_Get_Tag_SearchPat(fidx, tidx)
     let tpat_var = 's:tlist_' . a:fidx . '_' . a:tidx . '_tag_searchpat'
@@ -2150,7 +2237,7 @@ function! s:Tlist_Get_Tag_SearchPat(fidx, tidx)
         let end = end -1
     endif
     let {tpat_var} = '\V\^' . strpart(tag_line, start, end - start) .
-                \ (tag_line[end] == '$' ? '\$' : '')
+                        \ (tag_line[end] == '$' ? '\$' : '')
 
     return {tpat_var}
 endfunction
@@ -2232,7 +2319,7 @@ function! s:Tlist_Parse_Tagline(tag_line)
         " Add the tag scope, if it is available and is configured. Tag
         " scope is the last field after the 'line:<num>\t' field
         if g:Tlist_Display_Tag_Scope
-            let tag_scope = s:Tlist_Extract_Tag_Scope(a:tag_line)
+            let tag_scope = s:Tlist_Get_Tag_Scope(s:fidx, s:tidx)
             if tag_scope != ''
                 let ttxt = ttxt . ' [' . tag_scope . ']'
             endif
@@ -2321,9 +2408,13 @@ function! s:Tlist_Process_File(filename, ftype)
         " Contributed by: David Fishburn.
         let s:taglist_tempfile = fnamemodify(tempname(), ':h') .
                     \ '\taglist.cmd'
-        exe 'redir! > ' . s:taglist_tempfile
-        silent echo ctags_cmd
-        redir END
+        if v:version >= 700
+            call writefile([ctags_cmd], s:taglist_tempfile, "b")
+        else
+            exe 'redir! > ' . s:taglist_tempfile
+            silent echo ctags_cmd
+            redir END
+        endif
 
         call s:Tlist_Log_Msg('Cmd inside batch file: ' . ctags_cmd)
         let ctags_cmd = '"' . s:taglist_tempfile . '"'
@@ -2447,7 +2538,7 @@ function! s:Tlist_Process_File(filename, ftype)
                 " Add the tag scope, if it is available and is configured. Tag
                 " scope is the last field after the 'line:<num>\t' field
                 if g:Tlist_Display_Tag_Scope
-                    let tag_scope = s:Tlist_Extract_Tag_Scope(one_line)
+                    let tag_scope = s:Tlist_Get_Tag_Scope(fidx, tidx)
                     if tag_scope != ''
                         let ttxt = ttxt . ' [' . tag_scope . ']'
                     endif
@@ -2980,7 +3071,7 @@ endfunction
 " action == 'set', set the sort order to sort_type
 function! s:Tlist_Change_Sort(caller, action, sort_type)
     call s:Tlist_Log_Msg('Tlist_Change_Sort (caller = ' . a:caller .
-                \ ', action = ' . a:action . ', sort_type = ' . a:sort_type . ')')
+            \ ', action = ' . a:action . ', sort_type = ' . a:sort_type . ')')
     if a:caller == 'cmd'
         let fidx = s:Tlist_Window_Get_File_Index_By_Linenum(line('.'))
         if fidx == -1
@@ -3014,7 +3105,7 @@ function! s:Tlist_Change_Sort(caller, action, sort_type)
 
     if a:caller  == 'cmd'
         " Save the current line for later restoration
-        let curline = '\V\^' . getline('.') . '\$'
+        let curline = '\V\^' . escape(getline('.'), "\\") . '\$'
 
         call s:Tlist_Window_Refresh_File(s:tlist_{fidx}_filename,
                     \   s:tlist_{fidx}_filetype)
@@ -3065,7 +3156,7 @@ function! s:Tlist_Window_Update_File()
     match none
 
     " Save the current line for later restoration
-    let curline = '\V\^' . getline('.') . '\$'
+    let curline = '\V\^' . escape(getline('.'), "\\") . '\$'
 
     let s:tlist_{fidx}_valid = 0
 
@@ -3157,155 +3248,156 @@ function! s:Tlist_Window_Open_File(win_ctrl, filename, tagpat)
         call WinManagerFileEdit(a:filename, a:win_ctrl == 'newwin')
     else
 
-        if a:win_ctrl == 'newtab'
-            " Create a new tab
-            exe 'tabnew ' . escape(a:filename, ' ')
-            " Open the taglist window in the new tab
-            call s:Tlist_Window_Open()
-        endif
+    if a:win_ctrl == 'newtab'
+        " Create a new tab
+        exe 'tabnew ' . escape(a:filename, ' ')
+        " Open the taglist window in the new tab
+        call s:Tlist_Window_Open()
+    endif
 
-        if a:win_ctrl == 'checktab'
-            " Check whether the file is present in any of the tabs.
-            " If the file is present in the current tab, then use the
-            " current tab.
-            if bufwinnr(a:filename) != -1
-                let file_present_in_tab = 1
-                let i = tabpagenr()
-            else
-                let i = 1
-                let bnum = bufnr(a:filename)
-                let file_present_in_tab = 0
-                while i <= tabpagenr('$')
-                    if index(tabpagebuflist(i), bnum) != -1
-                        let file_present_in_tab = 1
-                        break
-                    endif
-                    let i += 1
-                endwhile
-            endif
-
-            if file_present_in_tab
-                " Goto the tab containing the file
-                exe 'tabnext ' . i
-            else
-                " Open a new tab
-                exe 'tabnew ' . escape(a:filename, ' ')
-
-                " Open the taglist window
-                call s:Tlist_Window_Open()
-            endif
-        endif
-
-        let winnum = -1
-        if a:win_ctrl == 'prevwin'
-            " Open the file in the previous window, if it is usable
-            let cur_win = winnr()
-            wincmd p
-            if &buftype == '' && !&previewwindow
-                exe "edit " . escape(a:filename, ' ')
-                let winnum = winnr()
-            else
-                " Previous window is not usable
-                exe cur_win . 'wincmd w'
-            endif
-        endif
-
-        " Goto the window containing the file.  If the window is not there, open a
-        " new window
-        if winnum == -1
-            let winnum = bufwinnr(a:filename)
-        endif
-
-        if winnum == -1
-            " Locate the previously used window for opening a file
-            let fwin_num = 0
-            let first_usable_win = 0
-
+    if a:win_ctrl == 'checktab'
+        " Check whether the file is present in any of the tabs.
+        " If the file is present in the current tab, then use the
+        " current tab.
+        if bufwinnr(a:filename) != -1
+            let file_present_in_tab = 1
+            let i = tabpagenr()
+        else
             let i = 1
-            let bnum = winbufnr(i)
-            while bnum != -1
-                if getwinvar(i, 'tlist_file_window') == 'yes'
-                    let fwin_num = i
+            let bnum = bufnr(a:filename)
+            let file_present_in_tab = 0
+            while i <= tabpagenr('$')
+                if index(tabpagebuflist(i), bnum) != -1
+                    let file_present_in_tab = 1
                     break
                 endif
-                if first_usable_win == 0 &&
-                            \ getbufvar(bnum, '&buftype') == '' &&
-                            \ !getwinvar(i, '&previewwindow')
-                    " First non-taglist, non-plugin and non-preview window
-                    let first_usable_win = i
-                endif
-                let i = i + 1
-                let bnum = winbufnr(i)
+                let i += 1
             endwhile
+        endif
 
-            " If a previously used window is not found, then use the first
-            " non-taglist window
-            if fwin_num == 0
-                let fwin_num = first_usable_win
-            endif
-
-            if fwin_num != 0
-                " Jump to the file window
-                exe fwin_num . "wincmd w"
-
-                " If the user asked to jump to the tag in a new window, then split
-                " the existing window into two.
-                if a:win_ctrl == 'newwin'
-                    split
-                endif
-                exe "edit " . escape(a:filename, ' ')
-            else
-                " Open a new window
-                if g:Tlist_Use_Horiz_Window
-                    exe 'leftabove split ' . escape(a:filename, ' ')
-                else
-                    if winbufnr(2) == -1
-                        " Only the taglist window is present
-                        if g:Tlist_Use_Right_Window
-                            exe 'leftabove vertical split ' .
-                                        \ escape(a:filename, ' ')
-                        else
-                            exe 'rightbelow vertical split ' .
-                                        \ escape(a:filename, ' ')
-                        endif
-
-                        " Go to the taglist window to change the window size to
-                        " the user configured value
-                        call s:Tlist_Exe_Cmd_No_Acmds('wincmd p')
-                        if g:Tlist_Use_Horiz_Window
-                            exe 'resize ' . g:Tlist_WinHeight
-                        else
-                            exe 'vertical resize ' . g:Tlist_WinWidth
-                        endif
-                        " Go back to the file window
-                        call s:Tlist_Exe_Cmd_No_Acmds('wincmd p')
-                    else
-                        " A plugin or help window is also present
-                        wincmd w
-                        exe 'leftabove split ' . escape(a:filename, ' ')
-                    endif
-                endif
-            endif
-            " Mark the window, so that it can be reused.
-            call s:Tlist_Window_Mark_File_Window()
+        if file_present_in_tab
+            " Goto the tab containing the file
+            exe 'tabnext ' . i
         else
-            if v:version >= 700
-                " If the file is opened in more than one window, then check
-                " whether the last accessed window has the selected file.
-                " If it does, then use that window.
-                let lastwin_bufnum = winbufnr(winnr('#'))
-                if bufnr(a:filename) == lastwin_bufnum
-                    let winnum = winnr('#')
-                endif
-            endif
-            exe winnum . 'wincmd w'
+            " Open a new tab
+            exe 'tabnew ' . escape(a:filename, ' ')
 
-            " If the user asked to jump to the tag in a new window, then split the
-            " existing window into two.
+            " Open the taglist window
+            call s:Tlist_Window_Open()
+        endif
+    endif
+
+    let winnum = -1
+    if a:win_ctrl == 'prevwin'
+        " Open the file in the previous window, if it is usable
+        let cur_win = winnr()
+        wincmd p
+        if &buftype == '' && !&previewwindow
+            exe "edit " . escape(a:filename, ' ')
+            let winnum = winnr()
+        else
+            " Previous window is not usable
+            exe cur_win . 'wincmd w'
+        endif
+    endif
+
+    " Goto the window containing the file.  If the window is not there, open a
+    " new window
+    if winnum == -1
+        let winnum = bufwinnr(a:filename)
+    endif
+
+    if winnum == -1
+        " Locate the previously used window for opening a file
+        let fwin_num = 0
+        let first_usable_win = 0
+
+        let i = 1
+        let bnum = winbufnr(i)
+        while bnum != -1
+            if getwinvar(i, 'tlist_file_window') == 'yes'
+                let fwin_num = i
+                break
+            endif
+            if first_usable_win == 0 &&
+                        \ getbufvar(bnum, '&buftype') == '' &&
+                        \ !getwinvar(i, '&previewwindow')
+                " First non-taglist, non-plugin and non-preview window
+                let first_usable_win = i
+            endif
+            let i = i + 1
+            let bnum = winbufnr(i)
+        endwhile
+
+        " If a previously used window is not found, then use the first
+        " non-taglist window
+        if fwin_num == 0
+            let fwin_num = first_usable_win
+        endif
+
+        if fwin_num != 0
+            " Jump to the file window
+            exe fwin_num . "wincmd w"
+
+            " If the user asked to jump to the tag in a new window, then split
+            " the existing window into two.
             if a:win_ctrl == 'newwin'
                 split
             endif
+            exe "edit " . escape(a:filename, ' ')
+        else
+            " Open a new window
+            let cmd_mod = (v:version >= 700) ? 'keepalt ' : ''
+            if g:Tlist_Use_Horiz_Window
+                exe cmd_mod . 'leftabove split ' . escape(a:filename, ' ')
+            else
+                if winbufnr(2) == -1
+                    " Only the taglist window is present
+                    if g:Tlist_Use_Right_Window
+                        exe cmd_mod . 'leftabove vertical split ' .
+                                    \ escape(a:filename, ' ')
+                    else
+                        exe cmd_mod . 'rightbelow vertical split ' .
+                                    \ escape(a:filename, ' ')
+                    endif
+
+                    " Go to the taglist window to change the window size to
+                    " the user configured value
+                    call s:Tlist_Exe_Cmd_No_Acmds('wincmd p')
+                    if g:Tlist_Use_Horiz_Window
+                        exe 'resize ' . g:Tlist_WinHeight
+                    else
+                        exe 'vertical resize ' . g:Tlist_WinWidth
+                    endif
+                    " Go back to the file window
+                    call s:Tlist_Exe_Cmd_No_Acmds('wincmd p')
+                else
+                    " A plugin or help window is also present
+                    wincmd w
+                    exe cmd_mod . 'leftabove split ' . escape(a:filename, ' ')
+                endif
+            endif
         endif
+        " Mark the window, so that it can be reused.
+        call s:Tlist_Window_Mark_File_Window()
+    else
+        if v:version >= 700
+            " If the file is opened in more than one window, then check
+            " whether the last accessed window has the selected file.
+            " If it does, then use that window.
+            let lastwin_bufnum = winbufnr(winnr('#'))
+            if bufnr(a:filename) == lastwin_bufnum
+                let winnum = winnr('#')
+            endif
+        endif
+        exe winnum . 'wincmd w'
+
+        " If the user asked to jump to the tag in a new window, then split the
+        " existing window into two.
+        if a:win_ctrl == 'newwin'
+            split
+        endif
+    endif
     endif
 
     " Jump to the tag
@@ -3459,7 +3551,8 @@ function! s:Tlist_Window_Show_Info()
     endif
 
     " Get the tag search pattern and display it
-    echo s:Tlist_Get_Tag_Prototype(fidx, tidx)
+    let proto = s:Tlist_Get_Tag_Prototype(fidx, tidx)
+    echo strpart(proto, 0, &columns - 1)
 endfunction
 
 " Tlist_Find_Nearest_Tag_Idx
@@ -3679,7 +3772,7 @@ function! Tlist_Get_Tag_Prototype_By_Line(...)
     else
         " Sufficient arguments are not supplied
         let msg =  'Usage: Tlist_Get_Tag_Prototype_By_Line <filename> ' .
-                    \ '<line_number>'
+                                \ '<line_number>'
         call s:Tlist_Warning_Msg(msg)
         return ""
     endif
@@ -3755,7 +3848,33 @@ function! Tlist_Get_Tagname_By_Line(...)
         return ""
     endif
 
-    return s:tlist_{fidx}_{tidx}_tag_name
+    let name = s:tlist_{fidx}_{tidx}_tag_name
+
+    if g:Tlist_Display_Tag_Scope
+        " Add the scope of the tag
+        let tag_scope = s:tlist_{fidx}_{tidx}_tag_scope
+        if tag_scope != ''
+            let name = name . ' [' . tag_scope . ']'
+        endif
+    endif
+
+    return name
+endfunction
+
+" Tlist_Get_Filenames
+" Return the list of file names in the taglist. The names are separated
+" by a newline ('\n')
+function! Tlist_Get_Filenames()
+    let fnames = ''
+
+    let i = 0
+
+    while i < s:tlist_file_count
+        let fnames = fnames . s:tlist_{i}_filename . "\n"
+        let i = i + 1
+    endwhile
+
+    return fnames
 endfunction
 
 " Tlist_Window_Move_To_File
@@ -3986,13 +4105,13 @@ function! s:Tlist_Session_Save(...)
     while i < s:tlist_file_count
         " Store information about the file
         silent! echo 'let tlist_' . i . "_filename = '" .
-                    \ s:tlist_{i}_filename . "'"
+                                            \ s:tlist_{i}_filename . "'"
         silent! echo 'let tlist_' . i . '_sort_type = "' .
-                    \ s:tlist_{i}_sort_type . '"'
+                                                \ s:tlist_{i}_sort_type . '"'
         silent! echo 'let tlist_' . i . '_filetype = "' .
-                    \ s:tlist_{i}_filetype . '"'
+                                            \ s:tlist_{i}_filetype . '"'
         silent! echo 'let tlist_' . i . '_tag_count = ' .
-                    \ s:tlist_{i}_tag_count
+                                                        \ s:tlist_{i}_tag_count
         " Store information about all the tags
         let j = 1
         while j <= s:tlist_{i}_tag_count
@@ -4014,9 +4133,9 @@ function! s:Tlist_Session_Save(...)
                 let txt = escape(s:tlist_{i}_{ttype}, '"\')
                 let txt = substitute(txt, "\n", "\\\\n", 'g')
                 silent! echo 'let tlist_' . i . '_' . ttype . ' = "' .
-                            \ txt . '"'
+                                                \ txt . '"'
                 silent! echo 'let tlist_' . i . '_' . ttype . '_count = ' .
-                            \ s:tlist_{i}_{ttype}_count
+                                                     \ s:tlist_{i}_{ttype}_count
                 let k = 1
                 while k <= s:tlist_{i}_{ttype}_count
                     silent! echo 'let tlist_' . i . '_' . ttype . '_' . k .
@@ -4138,6 +4257,28 @@ function! s:Tlist_Window_Check_Auto_Open()
     endif
 endfunction
 
+" Tlist_Create_Folds_For_File
+" Create the folds in the taglist window for the specified file
+function! s:Tlist_Create_Folds_For_File(fidx)
+    let ftype = s:tlist_{a:fidx}_filetype
+
+    " Create the folds for each tag type in a file
+    let j = 1
+    while j <= s:tlist_{ftype}_count
+        let ttype = s:tlist_{ftype}_{j}_name
+        if s:tlist_{a:fidx}_{ttype}_count
+            let s = s:tlist_{a:fidx}_start + s:tlist_{a:fidx}_{ttype}_offset
+            let e = s + s:tlist_{a:fidx}_{ttype}_count
+            exe s . ',' . e . 'fold'
+        endif
+        let j = j + 1
+    endwhile
+
+    exe s:tlist_{a:fidx}_start . ',' . s:tlist_{a:fidx}_end . 'fold'
+    exe 'silent! ' . s:tlist_{a:fidx}_start . ',' .
+                \ s:tlist_{a:fidx}_end . 'foldopen!'
+endfunction
+
 " Tlist_Refresh_Folds
 " Remove and create the folds for all the files displayed in the taglist
 " window. Used after entering a tab. If this is not done, then the folds
@@ -4154,28 +4295,18 @@ function! s:Tlist_Refresh_Folds()
     " First remove all the existing folds
     normal! zE
 
-    " Create the folds for each in the tag list
-    let fidx = 0
-    while fidx < s:tlist_file_count
-        let ftype = s:tlist_{fidx}_filetype
-
-        " Create the folds for each tag type in a file
-        let j = 1
-        while j <= s:tlist_{ftype}_count
-            let ttype = s:tlist_{ftype}_{j}_name
-            if s:tlist_{fidx}_{ttype}_count
-                let s = s:tlist_{fidx}_start + s:tlist_{fidx}_{ttype}_offset
-                let e = s + s:tlist_{fidx}_{ttype}_count
-                exe s . ',' . e . 'fold'
-            endif
-            let j = j + 1
+    if g:Tlist_Show_One_File 
+        " If only one file is displayed in the taglist window, then there
+        " is no need to refresh the folds for the tags as the tags for the
+        " current file will be removed anyway.
+    else
+        " Create the folds for each file in the tag list
+        let fidx = 0
+        while fidx < s:tlist_file_count
+            call s:Tlist_Create_Folds_For_File(fidx)
+            let fidx = fidx + 1
         endwhile
-
-        exe s:tlist_{fidx}_start . ',' . s:tlist_{fidx}_end . 'fold'
-        exe 'silent! ' . s:tlist_{fidx}_start . ',' .
-                    \ s:tlist_{fidx}_end . 'foldopen!'
-        let fidx = fidx + 1
-    endwhile
+    endif
 
     exe save_wnum . 'wincmd w'
 endfunction
@@ -4186,18 +4317,18 @@ function! s:Tlist_Menu_Add_Base_Menu()
     " Add the menu
     anoremenu <silent> T&ags.Refresh\ menu :call <SID>Tlist_Menu_Refresh()<CR>
     anoremenu <silent> T&ags.Sort\ menu\ by.Name
-                \ :call <SID>Tlist_Change_Sort('menu', 'set', 'name')<CR>
+                    \ :call <SID>Tlist_Change_Sort('menu', 'set', 'name')<CR>
     anoremenu <silent> T&ags.Sort\ menu\ by.Order
-                \ :call <SID>Tlist_Change_Sort('menu', 'set', 'order')<CR>
+                    \ :call <SID>Tlist_Change_Sort('menu', 'set', 'order')<CR>
     anoremenu T&ags.-SEP1-           :
 
     if &mousemodel =~ 'popup'
         anoremenu <silent> PopUp.T&ags.Refresh\ menu
                     \ :call <SID>Tlist_Menu_Refresh()<CR>
         anoremenu <silent> PopUp.T&ags.Sort\ menu\ by.Name
-                    \ :call <SID>Tlist_Change_Sort('menu', 'set', 'name')<CR>
+                  \ :call <SID>Tlist_Change_Sort('menu', 'set', 'name')<CR>
         anoremenu <silent> PopUp.T&ags.Sort\ menu\ by.Order
-                    \ :call <SID>Tlist_Change_Sort('menu', 'set', 'order')<CR>
+                  \ :call <SID>Tlist_Change_Sort('menu', 'set', 'order')<CR>
         anoremenu PopUp.T&ags.-SEP1-           :
     endif
 endfunction
@@ -4320,7 +4451,7 @@ function! s:Tlist_Menu_File_Refresh(fidx)
     " Update the popup menu (if enabled)
     if &mousemodel =~ 'popup'
         let cmd = substitute(s:tlist_{a:fidx}_menu_cmd, ' T\\&ags\.',
-                    \ ' PopUp.T\\\&ags.', "g")
+                                        \ ' PopUp.T\\\&ags.', "g")
         exe cmd
     endif
 
@@ -4585,7 +4716,6 @@ endfunction
 function! TagList_WrapUp()
     return 0
 endfunction
-
 
 " restore 'cpo'
 let &cpo = s:cpo_save


### PR DESCRIPTION
- `GoToSymbol` doesn't work with earlier versions of vim (specifically < 7.0). Vim reported an`E180: Invalid complete value`. Besides array support was only added in 7.0, so function `s:completeSymbols` won't work anyway.
- Updated Taglist version from 4.5 to 4.6.
- Now users with version < 7.0 would be able to use the plugin but without _tab completing_ the `tag` name. 
